### PR TITLE
Add .NET Standard 2.0 target framework

### DIFF
--- a/ReadableExpressions/ReadableExpressions.csproj
+++ b/ReadableExpressions/ReadableExpressions.csproj
@@ -1,78 +1,80 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <AssemblyTitle>AgileObjects.ReadableExpressions</AssemblyTitle>
-    <TargetFrameworks>net35;net40;netstandard1.0;</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
-    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
-    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <AssemblyName>AgileObjects.ReadableExpressions</AssemblyName>
-    <RootNamespace>AgileObjects.ReadableExpressions</RootNamespace>
-    <AssemblyOriginatorKeyFile>..\ReadableExpressions.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.0' ">1.6.1</NetStandardImplicitPackageVersion>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    
-    <AssemblyVersion>2.5.1.0</AssemblyVersion>
-    <FileVersion>2.5.1.0</FileVersion>
-    <VersionPrefix>2.5.1</VersionPrefix>
-    <Version>2.5.1</Version>
 
-    <PackageId>AgileObjects.ReadableExpressions</PackageId>
-    <Authors>Steve Wilkes</Authors>
-    <Company>AgileObjects Ltd</Company>
-    <Title>AgileObjects.ReadableExpressions</Title>
-    <Description>An extension method for Linq and DLR Expressions, producing readable, source-code versions of Expression Trees. Targets .NET 3.5+ and .NET Standard 1.0+</Description>
-    <Copyright>Copyright © AgileObjects Ltd 2020</Copyright>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageIcon>./Icon.png</PackageIcon>
-    <PackageTags>Expression Trees;Debugging;Debugger Visualizers</PackageTags>
-    <PackageProjectUrl>https://github.com/AgileObjects/ReadableExpressions</PackageProjectUrl>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/AgileObjects/ReadableExpressions</RepositoryUrl>
-    <PackageReleaseNotes>- Fixing empty block translation, re: #78
-- Fixing translation of non-array params argument values
-- Performance improvements
-    </PackageReleaseNotes>
-  </PropertyGroup>
+	<PropertyGroup>
+		<AssemblyTitle>AgileObjects.ReadableExpressions</AssemblyTitle>
+		<TargetFrameworks>net35;net40;netstandard1.0;netstandard2.0</TargetFrameworks>
+		<LangVersion>8.0</LangVersion>
+		<GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+		<GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<AssemblyName>AgileObjects.ReadableExpressions</AssemblyName>
+		<RootNamespace>AgileObjects.ReadableExpressions</RootNamespace>
+		<AssemblyOriginatorKeyFile>..\ReadableExpressions.snk</AssemblyOriginatorKeyFile>
+		<SignAssembly>true</SignAssembly>
+		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+		<NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.0' ">1.6.1</NetStandardImplicitPackageVersion>
+		<PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
 
-  <ItemGroup>
-    <None Include="../Icon.png" Pack="true" PackagePath="./" />
-  </ItemGroup>
+		<AssemblyVersion>2.5.1.0</AssemblyVersion>
+		<FileVersion>2.5.1.0</FileVersion>
+		<VersionPrefix>2.5.1</VersionPrefix>
+		<Version>2.5.1</Version>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
-  </PropertyGroup>
+		<PackageId>AgileObjects.ReadableExpressions</PackageId>
+		<Authors>Steve Wilkes</Authors>
+		<Company>AgileObjects Ltd</Company>
+		<Title>AgileObjects.ReadableExpressions</Title>
+		<Description>An extension method for Linq and DLR Expressions, producing readable, source-code versions of Expression Trees. Targets .NET 3.5+ and .NET Standard 1.0+</Description>
+		<Copyright>Copyright © AgileObjects Ltd 2020</Copyright>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+		<PackageIcon>./Icon.png</PackageIcon>
+		<PackageTags>Expression Trees;Debugging;Debugger Visualizers</PackageTags>
+		<PackageProjectUrl>https://github.com/AgileObjects/ReadableExpressions</PackageProjectUrl>
+		<RepositoryType>git</RepositoryType>
+		<RepositoryUrl>https://github.com/AgileObjects/ReadableExpressions</RepositoryUrl>
+		<PackageReleaseNotes>
+			- Fixing empty block translation, re: #78
+			- Fixing translation of non-array params argument values
+			- Performance improvements
+		</PackageReleaseNotes>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <Compile Include="..\ClsCompliant.cs">
-      <Link>Properties\ClsCompliant.cs</Link>
-    </Compile>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="../Icon.png" Pack="true" PackagePath="./" />
+	</ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net35'">
-    <PackageReference Include="DynamicLanguageRuntime">
-      <Version>1.1.2</Version>
-    </PackageReference>
-  </ItemGroup>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' OR '$(TargetFramework)' == 'netstandard2.0' ">
+		<DefineConstants>$(DefineConstants);NET_STANDARD</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
+	<ItemGroup>
+		<Compile Include="..\ClsCompliant.cs">
+			<Link>Properties\ClsCompliant.cs</Link>
+		</Compile>
+	</ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-  </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net35'">
+		<PackageReference Include="DynamicLanguageRuntime">
+			<Version>1.1.2</Version>
+		</PackageReference>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="AgileObjects.NetStandardPolyfills" Version="1.4.1" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+		<Reference Include="System" />
+		<Reference Include="Microsoft.CSharp" />
+	</ItemGroup>
 
-  <PropertyGroup>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-  </PropertyGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.0' ">
+		<PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="AgileObjects.NetStandardPolyfills" Version="1.4.1" />
+	</ItemGroup>
+
+	<PropertyGroup>
+		<FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
+	</PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Please add this target framework to minimize dependencies and make it compatible with the Unity 3D game engine which only supports .NET Standard 2.0+.