### PR TITLE
implement override dictionary for translations to expose to consumers

### DIFF
--- a/ReadableExpressions/ITranslationSettings.cs
+++ b/ReadableExpressions/ITranslationSettings.cs
@@ -1,6 +1,8 @@
 ﻿namespace AgileObjects.ReadableExpressions
 {
+    using AgileObjects.ReadableExpressions.Translations;
     using System;
+    using System.Collections.Generic;
     using Translations.Formatting;
 
     /// <summary>
@@ -92,5 +94,14 @@
         /// </param>
         /// <returns>These <see cref="ITranslationSettings"/>, to support a fluent API.</returns>
         ITranslationSettings FormatUsing(ITranslationFormatter formatter);
+
+        /// <summary>
+        /// Supply a set of ITranslations to override builtins <paramref name="overrides"/>.
+        /// </summary>
+        /// <param name="overrides">
+        /// The <see cref="ITranslation"/> with which to format Expression translations.
+        /// </param>
+        /// <returns>These <see cref="ITranslationSettings"/>, to support a fluent API.</returns>
+        ITranslationSettings OverrideTranslations(IEnumerable<Type> overrides);
     }
 }

--- a/ReadableExpressions/Translations/ExpressionTranslation.cs
+++ b/ReadableExpressions/Translations/ExpressionTranslation.cs
@@ -68,6 +68,11 @@
                 return translationExpression.GetTranslation(this);
             }
 
+            if (_settings.TranslationOverrides != null && _settings.TranslationOverrides.TryGetValue(expression.NodeType, out var ctor))
+            {
+                return ctor(expression, this);
+            }
+
             switch (expression.NodeType)
             {
                 case Decrement:

--- a/ReadableExpressions/Translations/IPotentialMultiStatementTranslatable.cs
+++ b/ReadableExpressions/Translations/IPotentialMultiStatementTranslatable.cs
@@ -1,7 +1,14 @@
 ﻿namespace AgileObjects.ReadableExpressions.Translations
 {
-    internal interface IPotentialMultiStatementTranslatable
+    /// <summary>
+    /// Implementing translation classes may generate no translation output.
+    /// </summary>
+    public interface IPotentialMultiStatementTranslatable
     {
+        /// <summary>
+        /// Gets a value indicating whether this <see cref="IPotentialMultiStatementTranslatable"/> will
+        /// generate no translation output.
+        /// </summary>
         bool IsMultiStatement { get; }
     }
 }


### PR DESCRIPTION
I am in need of the ability to override the translation you've implemented for specific Expression types. I'm exploring metaprogramming via ast -> expression trees -> sourcecode that would essentially be put into a .cs file. The following is probably not the implementation you'd want as maintainer. Please take a look and consider adding this functionality to ReadableExpressions. If the ITranslation required a static param for NodeType I wouldn't need to create an instance in order to add to the dictionary. I'm not sure how to get around the expression tree needed for the ctor. Please consider.. Thanks!

```
expr.ToReadableString(x =>
    {
        return x.ShowLambdaParameterTypes.OverrideTranslations(new[] { typeof(NewLambdaTranslation) });
    })
```